### PR TITLE
Proposed breaking changes for V2 (Stream)

### DIFF
--- a/stream/index.d.ts
+++ b/stream/index.d.ts
@@ -27,6 +27,14 @@ declare interface Stream<T> {
 declare namespace Stream {
 	/** Creates a computed stream that reactively updates if any of its upstreams are updated. */
 	export function combine<T>(combiner: (...streams: any[]) => T, streams: Array<Stream<any>>): Stream<T>;
+	/** Combines the values of one or more streams into a single stream that is updated whenever one or more of the sources are updated */
+	export function lift<A, Z>(fn: (a: A) => Z, s: Stream<A>): Stream<Z>;
+	export function lift<A, B, Z>(fn: (a: A, b: B) => Z, sa: Stream<A>, sb: Stream<B>): Stream<Z>;
+	export function lift<A, B, C, Z>(fn: (a: A, b: B, c: C) => Z, sa: Stream<A>, sb: Stream<B>, sc: Stream<C>): Stream<Z>;
+	export function lift<A, B, C, D, Z>(fn: (a: A, b: B, c: C, d: D) => Z, sa: Stream<A>, sb: Stream<B>, sc: Stream<C>, sd: Stream<D>): Stream<Z>;
+	export function lift<A, B, C, D, E, Z>(fn: (a: A, b: B, c: C, d: D, e: E) => Z, sa: Stream<A>, sb: Stream<B>, sc: Stream<C>, sd: Stream<D>, se: Stream<E>): Stream<Z>;
+	export function lift<A, B, C, D, E, F, Z>(fn: (a: A, b: B, c: C, d: D, e: E, f: F) => Z, sa: Stream<A>, sb: Stream<B>, sc: Stream<C>, sd: Stream<D>, se: Stream<E>, sf: Stream<F>): Stream<Z>;
+	export function lift<T>(fn: (...values: any[]) => T, ...streams: Stream<any>[]): Stream<T>;
 	/** Creates a stream whose value is the array of values from an array of streams. */
 	export function merge(streams: Array<Stream<any>>): Stream<any[]>;
 	/** Creates a new stream with the results of calling the function on every incoming stream with and accumulator and the incoming value. */

--- a/stream/index.d.ts
+++ b/stream/index.d.ts
@@ -43,8 +43,8 @@ declare namespace Stream {
 	export function scanMerge<T, U>(pairs: Array<[Stream<T>, (acc: U, value: T) => U]>, acc: U): Stream<U>;
 	/** Takes an array of pairs of streams and scan functions and merges all those streams using the given functions into a single stream. */
 	export function scanMerge<U>(pairs: Array<[Stream<any>, (acc: U, value: any) => U]>, acc: U): Stream<U>;
-	/** A special value that can be returned to stream callbacks to halt execution of downstreams. */
-	export const HALT: any;
+	/** A special value that can be returned to stream callbacks to skip execution of downstreams. */
+	export const SKIP: any;
 }
 
 export = Stream;

--- a/stream/index.d.ts
+++ b/stream/index.d.ts
@@ -1,42 +1,42 @@
-declare namespace Stream {
-	interface Stream<T> {
-		/** Returns the value of the stream. */
-		(): T;
-		/** Sets the value of the stream. */
-		(value: T): this;
-		/** Creates a dependent stream whose value is set to the result of the callback function. */
-		map(f: (current: T) => Stream<T> | T | void): Stream<T>;
-		/** Creates a dependent stream whose value is set to the result of the callback function. */
-		map<U>(f: (current: T) => Stream<U> | U): Stream<U>;
-		/** This method is functionally identical to stream. It exists to conform to Fantasy Land's Applicative specification. */
-		of(val?: T): Stream<T>;
-		/** Apply. */
-		ap<U>(f: Stream<(value: T) => U>): Stream<U>;
-		/** A co-dependent stream that unregisters dependent streams when set to true. */
-		end: Stream<boolean>;
-		/** When a stream is passed as the argument to JSON.stringify(), the value of the stream is serialized. */
-		toJSON(): string;
-		/** Returns the value of the stream. */
-		valueOf(): T;
-	}
+/** Creates an empty stream. */
+declare function Stream<T = any>(): Stream<T>;
+/** Creates a stream with an initial value. */
+declare function Stream<T>(value: T): Stream<T>;
 
-	interface Static {
-		/** Creates a stream. */
-		<T>(value?: T): Stream<T>;
-		/** Creates a computed stream that reactively updates if any of its upstreams are updated. */
-		combine<T>(combiner: (...streams: any[]) => T, streams: Array<Stream<any>>): Stream<T>;
-		/** Creates a stream whose value is the array of values from an array of streams. */
-		merge(streams: Array<Stream<any>>): Stream<any[]>;
-		/** Creates a new stream with the results of calling the function on every incoming stream with and accumulator and the incoming value. */
-		scan<T, U>(fn: (acc: U, value: T) => U, acc: U, stream: Stream<T>): Stream<U>;
-		/** Takes an array of pairs of streams and scan functions and merges all those streams using the given functions into a single stream. */
-		scanMerge<T, U>(pairs: Array<[Stream<T>, (acc: U, value: T) => U]>, acc: U): Stream<U>;
-		/** Takes an array of pairs of streams and scan functions and merges all those streams using the given functions into a single stream. */
-		scanMerge<U>(pairs: Array<[Stream<any>, (acc: U, value: any) => U]>, acc: U): Stream<U>;
-		/** A special value that can be returned to stream callbacks to halt execution of downstreams. */
-		readonly HALT: any;
-	}
+declare interface Stream<T> {
+	/** Returns the value of the stream. */
+	(): T;
+	/** Sets the value of the stream. */
+	(value: T): this;
+	/** Creates a dependent stream whose value is set to the result of the callback function. */
+	map(f: (current: T) => Stream<T> | T | void): Stream<T>;
+	/** Creates a dependent stream whose value is set to the result of the callback function. */
+	map<U>(f: (current: T) => Stream<U> | U): Stream<U>;
+	/** This method is functionally identical to stream. It exists to conform to Fantasy Land's Applicative specification. */
+	of(val?: T): Stream<T>;
+	/** Apply. */
+	ap<U>(f: Stream<(value: T) => U>): Stream<U>;
+	/** A co-dependent stream that unregisters dependent streams when set to true. */
+	end: Stream<boolean>;
+	/** When a stream is passed as the argument to JSON.stringify(), the value of the stream is serialized. */
+	toJSON(): string;
+	/** Returns the value of the stream. */
+	valueOf(): T;
 }
 
-declare const Stream: Stream.Static;
+declare namespace Stream {
+	/** Creates a computed stream that reactively updates if any of its upstreams are updated. */
+	export function combine<T>(combiner: (...streams: any[]) => T, streams: Array<Stream<any>>): Stream<T>;
+	/** Creates a stream whose value is the array of values from an array of streams. */
+	export function merge(streams: Array<Stream<any>>): Stream<any[]>;
+	/** Creates a new stream with the results of calling the function on every incoming stream with and accumulator and the incoming value. */
+	export function scan<T, U>(fn: (acc: U, value: T) => U, acc: U, stream: Stream<T>): Stream<U>;
+	/** Takes an array of pairs of streams and scan functions and merges all those streams using the given functions into a single stream. */
+	export function scanMerge<T, U>(pairs: Array<[Stream<T>, (acc: U, value: T) => U]>, acc: U): Stream<U>;
+	/** Takes an array of pairs of streams and scan functions and merges all those streams using the given functions into a single stream. */
+	export function scanMerge<U>(pairs: Array<[Stream<any>, (acc: U, value: any) => U]>, acc: U): Stream<U>;
+	/** A special value that can be returned to stream callbacks to halt execution of downstreams. */
+	export const HALT: any;
+}
+
 export = Stream;

--- a/test/test-api.ts
+++ b/test/test-api.ts
@@ -2,7 +2,7 @@
 // Not intended to be run; only to compile & check types.
 
 import * as m from '..';
-import * as stream from '../stream';
+import * as Stream from '../stream';
 
 const FRAME_BUDGET = 100;
 
@@ -441,9 +441,9 @@ const FRAME_BUDGET = 100;
 ////////////////////////////////////////////////////////////////////////////////
 
 {
-	const firstName = stream("John");
-	const lastName = stream("Doe");
-	const fullName = stream.merge([firstName, lastName]).map(values => {
+	const firstName = Stream("John");
+	const lastName = Stream("Doe");
+	const fullName = Stream.merge([firstName, lastName]).map(values => {
 		return values.join(" ");
 	});
 
@@ -459,8 +459,8 @@ const FRAME_BUDGET = 100;
 ////////////////////////////////////////////////////////////////////////////////
 
 {
-	const halted = stream(1).map(value => {
-		return stream.HALT;
+	const halted = Stream(1).map(value => {
+		return Stream.HALT;
 	});
 
 	halted.map(() => {
@@ -473,10 +473,10 @@ const FRAME_BUDGET = 100;
 ////////////////////////////////////////////////////////////////////////////////
 
 {
-	const a = stream(5);
-	const b = stream(7);
+	const a = Stream(5);
+	const b = Stream(7);
 
-	const added = stream.combine((a: stream.Stream<number>, b: stream.Stream<number>) => {
+	const added = Stream.combine((a: Stream<number>, b: Stream<number>) => {
 		return a() + b();
 	}, [a, b]);
 
@@ -488,7 +488,7 @@ const FRAME_BUDGET = 100;
 ////////////////////////////////////////////////////////////////////////////////
 
 {
-	const value = stream<number>();
+	const value = Stream<number>();
 	const doubled = value.map(value => value * 2);
 
 	value.end(true); // set to ended state

--- a/test/test-stream.ts
+++ b/test/test-stream.ts
@@ -1,8 +1,7 @@
-import * as stream from '../stream';
-import { Stream } from '../stream';
+import * as Stream from '../stream';
 
 {
-	const s = stream(1);
+	const s = Stream(1);
 	const initialValue = s();
 	s(2);
 	const newValue = s();
@@ -11,64 +10,64 @@ import { Stream } from '../stream';
 }
 
 {
-	const s = stream();
+	const s = Stream();
 	console.assert(s() === undefined);
 }
 
 {
-	const s: Stream<number | undefined> = stream(1);
+	const s: Stream<number | undefined> = Stream(1);
 	s(undefined);
 	console.assert(s() === undefined);
 }
 
 {
-	const s = stream(stream(1));
+	const s = Stream(Stream(1));
 	console.assert(s()() === 1);
 }
 
 {
-	const s = stream();
-	const doubled = stream.combine(s => s() * 2, [s]);
+	const s = Stream();
+	const doubled = Stream.combine(s => s() * 2, [s]);
 	s(2);
 	console.assert(doubled() === 4);
 }
 
 {
-	const s = stream(2);
-	const doubled = stream.combine(s => s() * 2, [s]);
+	const s = Stream(2);
+	const doubled = Stream.combine(s => s() * 2, [s]);
 	console.assert(doubled() === 4);
 }
 
 {
-	const s1 = stream();
-	const s2 = stream();
-	const added = stream.combine((s1, s2) => s1() + s2(), [s1, s2]);
+	const s1 = Stream<number>();
+	const s2 = Stream<number>();
+	const added = Stream.combine((s1, s2) => s1() + s2(), [s1, s2]);
 	s1(2);
 	s2(3);
 	console.assert(added() === 5);
 }
 
 {
-	const s1 = stream(2);
-	const s2 = stream(3);
-	const added = stream.combine((s1, s2) => s1() + s2(), [s1, s2]);
+	const s1 = Stream(2);
+	const s2 = Stream(3);
+	const added = Stream.combine((s1, s2) => s1() + s2(), [s1, s2]);
 	console.assert(added() === 5);
 }
 
 {
-	const s1 = stream(2);
-	const s2 = stream();
-	const added = stream.combine((s1, s2) => s1() + s2(), [s1, s2]);
+	const s1 = Stream(2);
+	const s2 = Stream();
+	const added = Stream.combine((s1, s2) => s1() + s2(), [s1, s2]);
 	s2(3);
 	console.assert(added() === 5);
 }
 
 {
 	let count = 0;
-	const a = stream();
-	const b = stream.combine(a => a() * 2, [a]);
-	const c = stream.combine(a => a() * a(), [a]);
-	const d = stream.combine((b, c) => {
+	const a = Stream();
+	const b = Stream.combine(a => a() * 2, [a]);
+	const c = Stream.combine(a => a() * a(), [a]);
+	const d = Stream.combine((b, c) => {
 		count++;
 		return b() + c();
 	}, [b, c]);
@@ -79,10 +78,10 @@ import { Stream } from '../stream';
 
 {
 	let count = 0;
-	const a = stream(3);
-	const b = stream.combine(a => a() * 2, [a]);
-	const c = stream.combine(a => a() * a(), [a]);
-	const d = stream.combine((b, c) => {
+	const a = Stream(3);
+	const b = Stream.combine(a => a() * 2, [a]);
+	const c = Stream.combine(a => a() * a(), [a]);
+	const d = Stream.combine((b, c) => {
 		count++;
 		return b() + c();
 	}, [b, c]);
@@ -92,9 +91,9 @@ import { Stream } from '../stream';
 
 {
 	let streams: Array<Stream<any>> = [];
-	const a = stream();
-	const b = stream();
-	const c = stream.combine((a, b, changed) => {
+	const a = Stream();
+	const b = Stream();
+	const c = Stream.combine((a, b, changed) => {
 		streams = changed;
 	}, [a, b]);
 	a(3);
@@ -105,9 +104,9 @@ import { Stream } from '../stream';
 
 {
 	let streams: Array<Stream<number>> = [];
-	const a = stream(3);
-	const b = stream(5);
-	const c = stream.combine((a, b, changed) => {
+	const a = Stream(3);
+	const b = Stream(5);
+	const c = Stream.combine((a, b, changed) => {
 		streams = changed;
 	}, [a, b]);
 	a(7);
@@ -116,37 +115,37 @@ import { Stream } from '../stream';
 }
 
 {
-	const a = stream(1);
-	const b = stream.combine(a => undefined, [a]);
+	const a = Stream(1);
+	const b = Stream.combine(a => undefined, [a]);
 
 	console.assert(b() === undefined);
 }
 
 {
-	const a = stream(1);
-	const b = stream.combine(a => stream(2), [a]);
+	const a = Stream(1);
+	const b = Stream.combine(a => Stream(2), [a]);
 	console.assert(b()() === 2);
 }
 
 {
-	const a = stream(1);
-	const b = stream.combine(a => stream(), [a]);
+	const a = Stream(1);
+	const b = Stream.combine(a => Stream(), [a]);
 	console.assert(b()() === undefined);
 }
 
 {
-	const all = stream.merge([
-		stream(10),
-		stream("20"),
-		stream({value: 30}),
+	const all = Stream.merge([
+		Stream(10),
+		Stream("20"),
+		Stream({value: 30}),
 	]);
 }
 
 {
-	const straggler = stream();
-	const all = stream.merge([
-		stream(10),
-		stream("20"),
+	const straggler = Stream();
+	const all = Stream.merge([
+		Stream(10),
+		Stream("20"),
 		straggler,
 	]);
 	console.assert(all() === undefined);
@@ -156,10 +155,10 @@ import { Stream } from '../stream';
 {
 	let value = 0;
 	const id = (value: number) => value;
-	const a = stream<number>();
-	const b = stream<number>();
+	const a = Stream<number>();
+	const b = Stream<number>();
 
-	const all = stream.merge([a.map(id), b.map(id)]).map(data => {
+	const all = Stream.merge([a.map(id), b.map(id)]).map(data => {
 		value = data[0] + data[1];
 	});
 
@@ -173,32 +172,32 @@ import { Stream } from '../stream';
 }
 
 {
-	const s = stream();
-	const doubled = stream.combine(stream => stream * 2, [s]);
+	const s = Stream();
+	const doubled = Stream.combine(stream => stream * 2, [s]);
 	s.end(true);
 	s(3);
 	console.assert(doubled() === undefined);
 }
 
 {
-	const s = stream(2);
-	const doubled = stream.combine(stream => stream * 2, [s]);
+	const s = Stream(2);
+	const doubled = Stream.combine(stream => stream * 2, [s]);
 	s.end(true);
 	s(3);
 	console.assert(doubled() === 4);
 }
 
 {
-	const s = stream(2);
+	const s = Stream(2);
 	s.end(true);
-	const doubled = stream.combine(stream => stream * 2, [s]);
+	const doubled = Stream.combine(stream => stream * 2, [s]);
 	s(3);
 	console.assert(doubled() === undefined);
 }
 
 {
-	const s = stream(2);
-	const doubled = stream.combine(stream => stream * 2, [s]);
+	const s = Stream(2);
+	const doubled = Stream.combine(stream => stream * 2, [s]);
 	doubled.end(true);
 	s(4);
 	console.assert(doubled() === 4);
@@ -207,33 +206,33 @@ import { Stream } from '../stream';
 // scan
 
 {
-	const parent = stream<number>();
-	const child = stream.scan((out, p) => out - p, 123, parent);
+	const parent = Stream<number>();
+	const child = Stream.scan((out, p) => out - p, 123, parent);
 }
 
 {
-	const parent = stream<number>();
-	const child = stream.scan((arr, p) => arr.concat(p), [] as number[], parent);
+	const parent = Stream<number>();
+	const child = Stream.scan((arr, p) => arr.concat(p), [] as number[], parent);
 	parent(7);
 }
 
 // scanMerge
 
 {
-	const parent1 = stream<number>();
-	const parent2 = stream<number>();
+	const parent1 = Stream<number>();
+	const parent2 = Stream<number>();
 
-	const child = stream.scanMerge([
+	const child = Stream.scanMerge([
 		[parent1, (out, p1) => out + p1],
 		[parent2, (out, p2) => out + p2]
 	], -10);
 }
 
 {
-	const parent1 = stream<string>();
-	const parent2 = stream<string>();
+	const parent1 = Stream<string>();
+	const parent2 = Stream<string>();
 
-	const child = stream.scanMerge([
+	const child = Stream.scanMerge([
 		[parent1, (out, p1) => out + p1],
 		[parent2, (out, p2) => out + p2 + p2]
 	], "a");
@@ -246,9 +245,9 @@ import { Stream } from '../stream';
 }
 
 {
-	const parent1 = stream<string>();
-	const parent2 = stream<number>();
-	const child = stream.scanMerge([
+	const parent1 = Stream<string>();
+	const parent2 = Stream<number>();
+	const child = Stream.scanMerge([
 		[parent1, (out, p1) => out + p1],
 		[parent2, (out, p2) => out + p2 + p2]
 	], "a");

--- a/test/test-stream.ts
+++ b/test/test-stream.ts
@@ -134,6 +134,21 @@ import * as Stream from '../stream';
 }
 
 {
+	const s = Stream(2);
+	const doubled = Stream.lift(v => v * 2, s);
+	console.assert(doubled() === 4);
+}
+
+{
+	const s1 = Stream<number>();
+	const s2 = Stream<number>();
+	const added = Stream.lift((n1, n2) => n1 + n2, s1, s2);
+	s1(2);
+	s2(3);
+	console.assert(added() === 5);
+}
+
+{
 	const all = Stream.merge([
 		Stream(10),
 		Stream("20"),


### PR DESCRIPTION
This merges the definitions for the Stream type and the "main" export into one. Now people can simply write

```typescript
import Stream from 'mithril/stream'
const s: Stream<number> = Stream(1)
```

@isiahmeadows @andraaspar are you ok with this change for when Mithril V2 releases?